### PR TITLE
DMOD-227 drop unused vertx-auth-jwt dependency

### DIFF
--- a/authtoken_module/pom.xml
+++ b/authtoken_module/pom.xml
@@ -23,11 +23,6 @@
       <version>3.2.1</version>
     </dependency>
     <dependency>
-      <groupId>io.vertx</groupId>
-      <artifactId>vertx-auth-jwt</artifactId>
-      <version>3.2.1</version>
-    </dependency>
-    <dependency>
       <groupId>io.jsonwebtoken</groupId>
       <artifactId>jjwt</artifactId>
       <version>0.6.0</version>


### PR DESCRIPTION
This avoids a security audit of vertx-auth-jwt.